### PR TITLE
diff generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@d2api/manifest": "^1.0.1",
+    "@d2api/manifest-patcher": "^1.0.0",
     "@types/fs-extra": "^9.0.1",
+    "@types/json-diff": "^0.5.0",
     "@types/lodash": "^4.14.161",
     "@types/node": "^14.0.1",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
@@ -22,6 +24,7 @@
     "fs": "^0.0.1-security",
     "fs-extra": "^9.0.1",
     "json-diff": "^0.5.4",
+    "lodash": "^4.17.20",
     "prettier-plugin-organize-imports": "^1.1.1",
     "typescript": "^3.9.2",
     "util": "^0.12.3"

--- a/src/findDifferentStrings.ts
+++ b/src/findDifferentStrings.ts
@@ -17,12 +17,17 @@ import _ from 'lodash';
 
   traverseObject(manifestEN, (foundValue, foundAtPath) => {
     if (typeof foundValue === 'string') {
+      // if we found a string, get the corresponding location from DE manifest and compare
       const stringDE = _.get(manifestDE, foundAtPath);
       if (typeof stringDE === 'string' && stringDE !== foundValue) {
         output.push([foundAtPath.join('.'), foundValue]);
       }
     }
   });
+  // all string/path combos
   console.log(output.length);
+  // unique translation-needed strings
+  console.log(new Set(output.map((a) => a[1]).filter(Boolean)).size);
+  // sample data
   console.log(JSON.stringify(output.slice(0, 3), null, 2));
 })();

--- a/src/findDifferentStrings.ts
+++ b/src/findDifferentStrings.ts
@@ -2,7 +2,6 @@ import { traverseObject } from '@d2api/manifest-patcher';
 import { allManifest, load, setLanguage, verbose } from '@d2api/manifest/node';
 import _ from 'lodash';
 
-let loops = 0;
 (async () => {
   const output: [string, string][] = [];
 
@@ -21,11 +20,9 @@ let loops = 0;
       const stringDE = _.get(manifestDE, foundAtPath);
       if (typeof stringDE === 'string' && stringDE !== foundValue) {
         output.push([foundAtPath.join('.'), foundValue]);
-        if (loops++ === 5) {
-          console.log(output);
-          process.exit();
-        }
       }
     }
   });
+  console.log(output.length);
+  console.log(JSON.stringify(output.slice(0, 3), null, 2));
 })();

--- a/src/findDifferentStrings.ts
+++ b/src/findDifferentStrings.ts
@@ -1,0 +1,31 @@
+import { traverseObject } from '@d2api/manifest-patcher';
+import { allManifest, load, setLanguage, verbose } from '@d2api/manifest/node';
+import _ from 'lodash';
+
+let loops = 0;
+(async () => {
+  const output: [string, string][] = [];
+
+  //load two manifests
+  verbose();
+  await load();
+  const manifestEN = allManifest! as any;
+  setLanguage('de');
+  await load();
+  const manifestDE = allManifest! as any;
+
+  // ok lets go
+
+  traverseObject(manifestEN, (foundValue, foundAtPath) => {
+    if (typeof foundValue === 'string') {
+      const stringDE = _.get(manifestDE, foundAtPath);
+      if (typeof stringDE === 'string' && stringDE !== foundValue) {
+        output.push([foundAtPath.join('.'), foundValue]);
+        if (loops++ === 5) {
+          console.log(output);
+          process.exit();
+        }
+      }
+    }
+  });
+})();

--- a/src/getD2ManifestEN.ts
+++ b/src/getD2ManifestEN.ts
@@ -2,4 +2,5 @@
 
 import manifest from '@d2api/manifest/node';
 
+manifest.verbose();
 manifest.load();

--- a/src/patcherExample.ts
+++ b/src/patcherExample.ts
@@ -1,0 +1,79 @@
+import { applyPatchList, applyPatchObject } from '@d2api/manifest-patcher';
+
+const obj1 = {
+  DestinyNodeStepSummaryDefinition: {
+    '19519556': {
+      displayProperties: {
+        description:
+          'Jump while airborne to activate Glide and start an airborne drift with a strong initial boost of speed.',
+        name: 'wrong', // name is wrong
+      },
+    },
+
+    // 32651606 is missing
+
+    '71216177': {
+      displayProperties: {}, // displayProperties is empty
+    },
+  },
+};
+
+// prettier-ignore
+const patches1: [string, string][] = [
+  ['19519556.displayProperties.name',        'Burst Glide'],
+
+  ['32651606.displayProperties.description', 'Dodge to perform a deft tumble, avoiding enemy attacks. Dodging near enemies fully recharges your Melee Ability.'],
+  ['32651606.displayProperties.name',        "Gambler's Dodge"],
+
+  ['71216177.displayProperties.description', ': After sprinting, leap into the air and use to slam into the ground and damage nearby targets.'],
+  ['71216177.displayProperties.name',        'Ballistic Slam'],
+];
+
+applyPatchList(obj1, patches1);
+
+console.log(JSON.stringify(obj1, null, 2));
+
+const obj2 = {
+  DestinyNodeStepSummaryDefinition: {
+    '19519556': {
+      displayProperties: {
+        description:
+          'Jump while airborne to activate Glide and start an airborne drift with a strong initial boost of speed.',
+        name: 'wrong', // name is wrong
+      },
+    },
+
+    // 32651606 is missing
+
+    '71216177': {
+      displayProperties: {}, // displayProperties is empty
+    },
+  },
+};
+
+// prettier-ignore
+const patches2 = {
+  "19519556": {
+    "displayProperties": {
+      "name": "Burst Glide"
+    }
+  },
+  "32651606": {
+    "displayProperties": {
+      "description": "Dodge to perform a deft tumble, avoiding enemy attacks. Dodging near enemies fully recharges your Melee Ability.",
+      "name": "Gambler's Dodge"
+    }
+  },
+  "71216177": {
+    "displayProperties": {
+      "description": ": After sprinting, leap into the air and use to slam into the ground and damage nearby targets.",
+      "name": "Ballistic Slam"
+    }
+  }
+};
+
+applyPatchObject(obj2, patches2);
+
+console.log(JSON.stringify(obj2, null, 2));
+
+console.log(JSON.stringify(obj1) === JSON.stringify(obj2));

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@d2api/manifest-patcher@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@d2api/manifest-patcher/-/manifest-patcher-1.0.0.tgz#d4bc3bbed69238f30c2e47c1899d0a9de505c2ed"
+  integrity sha512-vbHJUkmZ9Fvi9W8LbYN2/Zz17wf1+LkxS1S+wMTUZrKZA1rwLkfWjRAIBN5n6GfN8BXI3aPg6aFcVPXYuFQijA==
+
 "@d2api/manifest@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@d2api/manifest/-/manifest-1.0.1.tgz#271454a50908509e31aa5c4fff8c0315f9917755"
@@ -62,6 +67,11 @@
   integrity sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==
   dependencies:
     "@types/node" "*"
+
+"@types/json-diff@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@types/json-diff/-/json-diff-0.5.0.tgz#ee3690b61f5c62db71b3e0886077b7095b582967"
+  integrity sha512-muxLqd1I9S+aVADC50TDf7hcmeh3oipx6CdkHhSrx3eCCBErY1FgTHa9XCf5lDV9n88dfncu8HcsZedDOJv83Q==
 
 "@types/json-schema@^7.0.3":
   version "7.0.6"
@@ -1129,7 +1139,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
skips json-diff and manually finds strings to compare between EN and DE

demonstration file shows 2 different ways we could format the data before patching it back into the manifest

i am assuming an array of tuples is easier for the middle part where stuff gets translated

i was too lazy to steal/reimplement file writers, so maybe you can add something after the `traverseObject` finishes.
i just log a few sample lines from the results